### PR TITLE
a/button xpath, rhci automation tweaks

### DIFF
--- a/robottelo/test.py
+++ b/robottelo/test.py
@@ -189,6 +189,13 @@ class UITestCase(TestCase):
                 self.browser = webdriver.PhantomJS(
                     service_args=service_args
                 )
+            elif self.driver_name.lower() == 'wharf':
+                # set this test class's browser using the cfme_tests framework and config
+                # sort of a dirty hack, but it gets things moving, which is what we need
+                # to get here, main.remote must be 1, and sauce.driver must be wharf
+                # Note that this will cause the browser to be reused, contrary to the docstring
+                from utils.browser import ensure_browser_open
+                self.browser = ensure_browser_open()
             else:
                 self.browser = webdriver.Remote()
         else:

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -1937,10 +1937,7 @@ locators = LocatorDict({
     "rhci.new": (
         By.XPATH, "//a[contains(.,'New Deployment')]"),
     "rhci.next": (
-        By.XPATH, "//a[contains(.,'Next') and contains(@class, 'btn-primary') and not(contains(@class, 'disabled'))]"),
-    # TODO: file a bug for this (next button is sometimes <a>, sometimes <button> )
-    "rhci.lifecycle_next": (
-        By.XPATH, "//button[contains(.,'Next') and contains(@class, 'btn-primary')and not(contains(@class, 'disabled'))]"),
+        By.XPATH, "(//a|//button)[contains(.,'Next') and contains(@class, 'btn-primary') and not(contains(@class, 'disabled'))]"),
     "rhci.select": (
         By.XPATH, "//a[contains(.,'Select') and contains(@class, 'btn-primary') and not(contains(@class, 'disabled'))]"),
     "rhci.satellite_name": (
@@ -2007,6 +2004,8 @@ locators = LocatorDict({
         "//div[@class='wizard-block']//li[contains(.,'Subscriptions')]/div"),
     "rhci.cfme_install_on": (
         By.XPATH, "//input[@type='radio' and @value='%s']"),
+    "rhci.cfme_admin_password": (
+        By.XPATH, "//input[@id='cfme_admin_password']"),
     "rhci.cfme_root_password": (
         By.XPATH, "//input[@id='cfme_root_password']"),
     # TODO: File BZ, these rhsm inputs need IDs.

--- a/robottelo/ui/rhci.py
+++ b/robottelo/ui/rhci.py
@@ -4,6 +4,7 @@
 """
 Implements RHCI UI
 """
+from time import sleep
 
 from robottelo.ui.base import Base
 from robottelo.ui.locators import locators
@@ -21,8 +22,7 @@ class RHCI(Base):
                data_domain_name=None, export_domain_name=None, data_domain_address=None,
                export_domain_address=None, data_domain_share_path=None,
                export_domain_share_path=None,cfme_install_loc=None,
-               cfme_root_password=None,
-               ):
+               cfme_root_password=None, cfme_admin_password=None):
         """
         Creates a new RHCI deployment with the provided details.
         """
@@ -41,12 +41,15 @@ class RHCI(Base):
         # RHCI: Lifecycle environment page
         if use_default_org_view:
             self.wait_until_element(locators["rhci.use_default_org_view"]).click()
+            # weird trashing happens here that breaks waiting for the next button
+            # unfortunately, the best I have right now to fix it is a sleep
+            sleep(3)
             self.wait_until_element(locators["rhci.next"]).click()
         elif self.wait_until_element((locators["rhci.env_path"][0],
                                     locators["rhci.env_path"][1] % env_path)):
             self.find_element((locators["rhci.env_path"][0],
                                locators["rhci.env_path"][1] % env_path)).click()
-            self.wait_until_element(locators["rhci.lifecycle_next"]).click()
+            self.wait_until_element(locators["rhci.next"]).click()
         else:
             print "Can't find env_path: %s" % env_path
         # RHCI: RHEV Setup Type page.
@@ -69,7 +72,7 @@ class RHCI(Base):
                                         locators["rhci.hypervisor_mac_check"][1] % mac_address)):
                 self.find_element((locators["rhci.hypervisor_mac_check"][0],
                                    locators["rhci.hypervisor_mac_check"][1] % mac_address)).click()
-        self.wait_until_element(locators["rhci.lifecycle_next"]).click()
+        self.wait_until_element(locators["rhci.next"]).click()
         # RHCI: RHEV Configuration page.
         if self.wait_until_element(locators["rhci.rhev_root_pass"]):
             self.find_element(locators["rhci.rhev_root_pass"]).send_keys(rhevm_adminpass)
@@ -83,6 +86,7 @@ class RHCI(Base):
         self.wait_until_element(locators["rhci.next"]).click()
         # RHCI: RHEV Storage page.
         if self.wait_until_element(locators["rhci.data_domain_name"]):
+            # XXX name fields aren't cleared before typing :(
             self.find_element(locators["rhci.data_domain_name"]).send_keys(data_domain_name)
             self.find_element(locators["rhci.data_domain_address"]).send_keys(data_domain_address)
             self.find_element(locators["rhci.data_domain_share_path"]).send_keys(data_domain_share_path)
@@ -97,12 +101,13 @@ class RHCI(Base):
                                locators['rhci.cfme_install_on'][1] % cfme_install_loc)).click()
         self.wait_until_element(locators['rhci.next']).click()
         self.wait_until_element(locators['rhci.cfme_root_password']).send_keys(cfme_root_password)
+        self.wait_until_element(locators['rhci.cfme_admin_password']).send_keys(cfme_admin_password)
         self.wait_until_element(locators['rhci.next']).click()
         # RHCI: Subscription Credentials page.
         if self.wait_until_element(locators['rhci.rhsm_username']):
             self.find_element(locators['rhci.rhsm_username']).send_keys(rhsm_username)
             self.find_element(locators['rhci.rhsm_password']).send_keys(rhsm_password)
-        self.wait_until_element(locators["rhci.lifecycle_next"]).click()
+        self.wait_until_element(locators["rhci.next"]).click()
         # RHCI: Subscription Management Application.
         self.wait_until_element((locators["rhci.rhsm_satellite_radio"][0],
                                  locators["rhci.rhsm_satellite_radio"][1] % rhsm_satellite_uuid)).click()
@@ -113,6 +118,6 @@ class RHCI(Base):
                                         locators["rhci.subscription_check"][1] % sub)):
                 self.wait_until_element((locators["rhci.subscription_check"][0],
                                          locators["rhci.subscription_check"][1] % sub)).click()
-        self.wait_until_element(locators["rhci.lifecycle_next"]).click()
+        self.wait_until_element(locators["rhci.next"]).click()
         # RCHI: Review Installation page.
         self.wait_until_element(locators["rhci.deploy"]).click()


### PR DESCRIPTION
I added support for the cfme_admin_password, which I believe allows you to set the CFME UI password independently of the root password.

I also removed the rhci.lifecycle_next locator, in favor of the element OR syntax we talked about earlier.
