### PR TITLE
disable_existing_loggers=False so it doesn't destroy other loggers

### DIFF
--- a/robottelo/common/__init__.py
+++ b/robottelo/common/__init__.py
@@ -93,7 +93,8 @@ def _configure_logging(verbosity=2):
 
     """
     try:
-        config.fileConfig(os.path.join(get_app_root(), 'logging.conf'))
+        config.fileConfig(os.path.join(get_app_root(), 'logging.conf'),
+                          disable_existing_loggers=False)
     except NoSectionError:
         logging.basicConfig(
             format='%(levelname)s %(module)s:%(lineno)d: %(message)s'


### PR DESCRIPTION
This will prevent robottelo from aggressively destroying all other loggers used by modules that import robottelo
