### PR TITLE
Update locators for product selection in QCI 1.1

### DIFF
--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -1937,9 +1937,9 @@ locators = LocatorDict({
     "rhci.new": (
         By.XPATH, "//a[contains(.,'New Deployment')]"),
     "rhci.product_select": (
-        By.XPATH, "//span[contains(@id,'%s')]/div[contains(@class, 'rhci-footer-unselected')]"),
+        By.XPATH, "//span[contains(@id,'%s')]/div[contains(@class, 'product-item-checkbox')]/input"),
     "rhci.product_deselect": (
-        By.XPATH, "//span[contains(@id,'%s')]/div[contains(@class, 'rhci-footer-selected')]"),
+        By.XPATH, "//span[contains(@id,'%s')]/div[contains(@class, 'product-item-checkbox')]/input"),
     "rhci.next": (
         By.XPATH, "(//a|//button)[contains(.,'Next') and contains(@class, 'btn-primary') and not(contains(@class, 'disabled'))]"),
     "rhci.select": (

--- a/robottelo/ui/rhci.py
+++ b/robottelo/ui/rhci.py
@@ -103,7 +103,7 @@ class RHCI(Base):
         # Select products to install
         for prod in products:
             self.click(interp_loc('rhci.product_select', prod))
-        self.click(locators["rhci.select"])
+        self.click(locators["rhci.next"])
 
     def _page_satellite_configuration(self, sat_name, sat_desc, org_present_locator):
         # RHCI: Satellite Configuration


### PR DESCRIPTION
QCI 1.1 adds support for deploying OpenShift and changed the production
selection page elements. This updates for xpaths for the products and
replaces the select button
