### PR TITLE
Take screenshot when assign OSP role elems missing

### DIFF
--- a/robottelo/ui/rhci.py
+++ b/robottelo/ui/rhci.py
@@ -228,6 +228,7 @@ class RHCI(Base):
                         locators['rhci.node_assign_role'], timeout=180):
                     print 'Assign Nodes ({}): Assign role is not a clickable element'.format(
                             role['name'])
+                    self.browser.save_screenshot_as_file('assign_role_missing.png')
                     raise Exception('Unable to proceed because Assign Role element is missing')
 
                 print 'Clicking assign role'
@@ -235,6 +236,8 @@ class RHCI(Base):
 
                 if not self.wait_until_element_is_clickable(role['locator'], timeout=30):
                     print 'Assign Nodes: Timeout while waiting for {} role'.format(role['name'])
+                    self.browser.save_screenshot_as_file('assign_role_missing_{}.png'.format(role['name']))
+                    raise Exception('Unable to proceed because Assign Role element is missing for {}'.format(role['name']))
                 print 'Assigning {} role'.format(role['name'])
                 self.click(role['locator'])
 


### PR DESCRIPTION
During the OSP role assignment, we will try to take a screenshot if an element is missing.
